### PR TITLE
Add Strawberry CSS to Specialized Frameworks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,11 @@ Frameworks that are smaller than ~5KB.
   [Docs](http://bojler.slicejack.com/getting-started/),
   [Repo](https://github.com/Slicejack/bojler)
 
+- [**Strawberry**](https://github.com/jfet97/strawberry) - A set of common flexbox's utilities focused on making your life easier and faster with nested flexboxes.  
+  ![](https://img.shields.io/github/stars/jfet97/strawberry.svg?style=social&label=Star)
+  [repo](https://github.com/jfet97/strawberry),
+  [wiki](https://github.com/jfet97/strawberry/wiki),
+  [website](https://jfet97.github.io/strawberry/)
 
 ## Stalled Development
 


### PR DESCRIPTION
**Strawberry** is a new flexbox based CSS micro-framework, a set of common flexbox's utilities focused on making life easier and faster with nested flexboxes. You can easily create nested flexboxes directly from the container.
So it can also considered like a fallback for CSS Grid.
It is written in SASS and it could be installed using node, forking the repo or using the CDN.


Some good points of it:
1. It's light: less than 12Kb
2. It’s powerful: create Flexbox-based layouts in few lines of code
3. No preset graphic style: it helps you create layouts without messing up your life
4. No conflicts with other used framework in the same project: all classes start with the sb- prefix
5. Easy to override: strawberry never use !important

I started this project on June 5th 2018 so I am non perfectly compliant with your guidelines.
But recently [awesome-css-group](https://github.com/awesome-css-group/awesome-css) added me in their list. Maybe my project is enough relevant for you as well.


Useful links:
* [repo](https://github.com/jfet97/strawberry)
* [wiki](https://github.com/jfet97/strawberry/wiki)
* [website](https://jfet97.github.io/strawberry/)
* [medium](https://medium.com/@andreasimonecosta/strawberry-a-new-flexbox-based-css-micro-framework-42ff9be49468)