### PR TITLE
Change Wing website, current site is spam

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ Frameworks that are smaller than ~5KB.
   [Demo](https://oxal.org/projects/sakura/demo/),
   [Repo](https://github.com/oxalorg/sakura)
 
-- [**Wing**](http://usewing.ml/) - Beautiful CSS framework designed for minimalists.  
+- [**Wing**](https://kbrsh.github.io/wing/) - Beautiful CSS framework designed for minimalists.  
   ![](https://img.shields.io/github/stars/kbrsh/wing.svg?style=social&label=Star)
   [Repo](https://github.com/kbrsh/wing)
 


### PR DESCRIPTION
[Current website in README](http://usewing.ml/) keeps actually forwarding me to various spam websites. Checking the project repo, it looks like the correct url is [this one](https://kbrsh.github.io/wing/).

Here reference: [https://github.com/kbrsh/wing](https://github.com/kbrsh/wing)