### PR TITLE
Add HTML5Boilerplate's main.css project

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,11 @@ Feel free to [contribute](https://github.com/troxler/awesome-css-frameworks/blob
   [Repo](https://github.com/csstools/sanitize.css)
   | #CSS
 
+- [**main.css**](https://github.com/h5bp/main.css) - The HTML5 Boilerplate CSS.  
+  ![](https://img.shields.io/github/stars/h5bp/main.css.svg?style=social&label=Star)
+  [Repo](https://github.com/h5bp/main.css)
+  | #CSS
+
 - [**minireset.css**](http://jgthms.com/minireset.css/) - Tiny modern CSS reset.  
   ![](https://img.shields.io/github/stars/jgthms/minireset.css.svg?style=social&label=Star)
   [Repo](https://github.com/jgthms/minireset.css)


### PR DESCRIPTION
I'm a maintainer on the [HTML5 Boilerplate](https://github.com/h5bp/html5-boilerplate) project. We moved the CSS to a separate repo (now called 'main.css') last year. It provides many useful baseline styles and features and I think is a worthy addition to your list.