### PR TITLE
Added Pico.css, class-less CSS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,10 @@ Feel free to [contribute](https://github.com/troxler/awesome-css-frameworks/blob
 ## Class-less
 
 Frameworks that use semantic HTML and do not rely on classes.
+- [**Pico.css**](https://picocss.com/) - Minimal CSS Framework for semantic HTML  
+  ![](https://img.shields.io/github/stars/picocss/pico.svg?style=social&label=Star)
+  [Repo](https://github.com/picocss/pico)
+  | #CSS #Sass
 
 - [**Water.css**](https://watercss.kognise.dev/) - Just-add-CSS collection of styles to make simple websites just a little nicer.  
   ![](https://img.shields.io/github/stars/kognise/water.css.svg?style=social&label=Star)

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ Frameworks that use semantic HTML and do not rely on classes.
 - [**Pico.css**](https://picocss.com/) - Minimal CSS Framework for semantic HTML  
   ![](https://img.shields.io/github/stars/picocss/pico.svg?style=social&label=Star)
   [Demo](https://picocss.com/#examples),
+  [Docs](https://picocss.com/docs/),
   [Repo](https://github.com/picocss/pico)
   | #CSS #Sass
 

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Feel free to [contribute](https://github.com/troxler/awesome-css-frameworks/blob
 Frameworks that use semantic HTML and do not rely on classes.
 - [**Pico.css**](https://picocss.com/) - Minimal CSS Framework for semantic HTML  
   ![](https://img.shields.io/github/stars/picocss/pico.svg?style=social&label=Star)
-  [Demo](https://picocss.com/#examples)
+  [Demo](https://picocss.com/#examples),
   [Repo](https://github.com/picocss/pico)
   | #CSS #Sass
 

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ Feel free to [contribute](https://github.com/troxler/awesome-css-frameworks/blob
 Frameworks that use semantic HTML and do not rely on classes.
 - [**Pico.css**](https://picocss.com/) - Minimal CSS Framework for semantic HTML  
   ![](https://img.shields.io/github/stars/picocss/pico.svg?style=social&label=Star)
+  [Demo](https://picocss.com/#examples)
   [Repo](https://github.com/picocss/pico)
   | #CSS #Sass
 


### PR DESCRIPTION
Adding Pico.css, a class-less CSS framework with 10.3k stars on Github.
It makes it to the top of the list of class-less CSS framework ordered by stars.