### PR TITLE
Update Vanilla framework repo link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ Frameworks that are smaller than ~5KB.
   ![](https://img.shields.io/github/stars/canonical-web-and-design/vanilla-framework.svg?style=social&label=Star)
   [Demo](https://vanillaframework.io/docs/examples),
   [Docs](https://vanillaframework.io/docs/),
-  [Repo](https://github.com/canonical-web-and-design/vanilla-framework)
+  [Repo](https://github.com/canonical/vanilla-framework)
   | #SCSS
 
 - [**PatternFly**](https://www.patternfly.org/) - UI framework for enterprise web applications.  


### PR DESCRIPTION
## Done

Updated the Vanilla framework repo link

## QA

1. Check the new link goes directly to the repo without a redirect.