### PR TITLE
Add µCSS – General purpose framework with 17 components, 20 themes, n…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,13 @@ Frameworks that are smaller than ~10KB.
   [Repo](https://github.com/jonathanharrell/hiq/)
   | #PostCSS
 
+- [**µCSS**](https://mucss.org) - Full-featured CSS framework, with 17 components, 20 color themes, a 12-column responsive grid, and dark mode. No build step required.  
+  ![]([https://img.shields.io/github/stars/jonathanharrell/hiq.svg?style=social&label=Star](https://img.shields.io/github/stars/Digicreon/muCSS.svg?style=social&label=Star))
+  [Demo](https://mucss.org),
+  [Docs](https://mucss.org),
+  [Repo](https://github.com/Digicreon/muCSS)
+  | #CSS
+
 
 ## Material Design
 


### PR DESCRIPTION
…o build step

## What

Adds µCSS to the **General Purpose** section.

## About µCSS

- **Website**: https://mucss.org
- **Repo**: https://github.com/Digicreon/muCSS
- **npm**: `@digicreon/mucss`

µCSS is built on top of PicoCSS v2 and extends it with everything PicoCSS intentionally omits:

- 17 UI components (accordion, modal, toast, tabs, nav, breadcrumb, badge, alert, card, hero...)
- 20 color themes (one self-contained CSS file per theme)
- 12-column responsive grid (5 breakpoints, offsets, ordering, display utilities)
- Color and positioning utility classes
- Dark mode (automatic or manual)
- ~19KB gzipped

Pure CSS, no JavaScript dependency, no build tool required (no Node.js, no SASS). Each theme is a single file, usable via CDN:
```html
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@digicreon/mucss/dist/mu.css">
```

## Checklist

- [x] The framework is production-ready
- [x] The framework is actively maintained
- [x] Entry follows the existing format
- [x] Links are valid